### PR TITLE
AVO-1415: Fix duplicated image & media library pagination in rhino field

### DIFF
--- a/app/components/avo/fields/rhino_field/edit_component.html.erb
+++ b/app/components/avo/fields/rhino_field/edit_component.html.erb
@@ -44,7 +44,7 @@
         class="toolbar__button rhino-toolbar-button flex flex-col items-center grow-0 text-sm hidden-until-rhino-boots-up"
         data-role="toolbar-item"
         tabindex="-1"
-        href="<%= helpers.avo.attach_media_path(resource_name: @resource.name, record_id: @resource.id, controller_selector: ".#{unique_id}", controller_name: 'rhino-field') %>"
+        href="<%= helpers.avo.attach_media_path(resource_name: @resource.name, record_id: @resource.id, controller_selector: ".#{unique_id}", controller_name: 'rhino-field', turbo_frame: ::Avo::MODAL_FRAME_ID) %>"
         data-turbo-frame="<%= ::Avo::MODAL_FRAME_ID %>"
       >
         <%= helpers.svg "heroicons/outline/photo", class: "!min-h-4 !max-h-4" %>

--- a/app/javascript/controllers/rhino_editor.js
+++ b/app/javascript/controllers/rhino_editor.js
@@ -1,9 +1,26 @@
 import { TipTapEditor } from 'rhino-editor'
+import { Attachment, PreviewableAttachment } from 'rhino-editor/exports/extensions/attachment.js'
 import Document from '@tiptap/extension-document'
 import Paragraph from '@tiptap/extension-paragraph'
 import Text from '@tiptap/extension-text'
 import TextStyle from '@tiptap/extension-text-style'
 import { HexColor } from './rhino-extensions/hex_color'
+
+// Fix duplicated image after save -> edit (AVO-1415 #6): scope the
+// `figure[data-trix-attachment]` parse rule to its <figcaption> so the inner
+// <img> isn't re-parsed alongside the figure's regenerated one.
+const scopeAttachmentContentToCaption = {
+  parseHTML() {
+    return (this.parent?.() ?? []).map((rule) => (
+      rule.tag === 'figure[data-trix-attachment]'
+        ? { ...rule, contentElement: 'figcaption' }
+        : rule
+    ))
+  },
+}
+
+const PatchedAttachment = Attachment.extend(scopeAttachmentContentToCaption)
+const PatchedPreviewableAttachment = PreviewableAttachment.extend(scopeAttachmentContentToCaption)
 
 export default class RhinoEditor extends TipTapEditor {
   constructor() {
@@ -23,6 +40,8 @@ export default class RhinoEditor extends TipTapEditor {
       Text,
       TextStyle,
       HexColor,
+      PatchedAttachment,
+      PatchedPreviewableAttachment,
     ]
   }
 }

--- a/app/javascript/controllers/rhino_editor.js
+++ b/app/javascript/controllers/rhino_editor.js
@@ -6,10 +6,11 @@ import Text from '@tiptap/extension-text'
 import TextStyle from '@tiptap/extension-text-style'
 import { HexColor } from './rhino-extensions/hex_color'
 
-// Fix duplicated image after save -> edit (AVO-1415 #6): scope the
-// `figure[data-trix-attachment]` parse rule to its <figcaption> so the inner
-// <img> isn't re-parsed alongside the figure's regenerated one.
-const scopeAttachmentContentToCaption = {
+// Fixes for rhino-editor's attachment figure extensions (AVO-1415).
+const attachmentFixes = {
+  // #6 — duplicated image after save -> edit: scope the
+  // `figure[data-trix-attachment]` parse rule to its <figcaption> so the inner
+  // <img> isn't re-parsed alongside the figure's regenerated one.
   parseHTML() {
     return (this.parent?.() ?? []).map((rule) => (
       rule.tag === 'figure[data-trix-attachment]'
@@ -17,10 +18,39 @@ const scopeAttachmentContentToCaption = {
         : rule
     ))
   },
+
+  // Image sometimes "expands" to a cover instead of being deleted: rhino's
+  // removeFigure does `tr.delete(pos, pos + 1)` — a fixed size-1 range that can
+  // leave the figure partially in the doc (e.g. lifted out of its gallery, then
+  // re-rendered full width). Override it to delete the whole node by its real
+  // nodeSize. Wrap the parent node view so rendering is otherwise untouched.
+  addNodeView() {
+    const parentAddNodeView = this.parent?.()
+    if (!parentAddNodeView) return undefined
+
+    return (props) => {
+      const nodeView = parentAddNodeView(props)
+      const { editor, getPos } = props
+      const attachmentEditor = nodeView?.dom?.querySelector?.('rhino-attachment-editor')
+
+      if (attachmentEditor) {
+        attachmentEditor.removeFigure = () => {
+          if (typeof getPos !== 'function') return
+          const pos = getPos()
+          if (pos == null) return
+          const node = editor.state.doc.nodeAt(pos)
+          if (!node) return
+          editor.view.dispatch(editor.state.tr.delete(pos, pos + node.nodeSize))
+        }
+      }
+
+      return nodeView
+    }
+  },
 }
 
-const PatchedAttachment = Attachment.extend(scopeAttachmentContentToCaption)
-const PatchedPreviewableAttachment = PreviewableAttachment.extend(scopeAttachmentContentToCaption)
+const PatchedAttachment = Attachment.extend(attachmentFixes)
+const PatchedPreviewableAttachment = PreviewableAttachment.extend(attachmentFixes)
 
 export default class RhinoEditor extends TipTapEditor {
   constructor() {


### PR DESCRIPTION
Fixes for [AVO-1415](https://linear.app/avo-hq/issue/AVO-1415/fix-the-avo-rhino-field-component).

## What's fixed

### Duplicated image after save → edit (item #6)
rhino-editor serializes an image attachment as `<figure data-trix-attachment><img>…<figcaption></figure>`. On reload, its `figure[data-trix-attachment]` parse rule had no `contentElement`, so the inner `<img>` was re-parsed into a separate `attachment-image` node **while** the figure also regenerated its own image from attributes → **two images** (the second rendered as the gallery "cover").

This was also the cause of the **"delete an image and the same image reappears as a cover"** symptom: the two representations were separate, so deleting one left the figure's regenerated cover behind.

**Fix:** patch the `Attachment` / `PreviewableAttachment` extensions so the `figure[data-trix-attachment]` rule scopes its parsed content to `<figcaption>` — exactly how the ActionText (`action-text-attachment`) path already behaves. ProseMirror then skips the inner `<img>`, leaving only the figure's single image.

> Normal rhino-editor apps don't hit this because they store ActionText (`<action-text-attachment>`), which already scopes to the caption. This gem stores `body` as a plain text column, so the raw Trix HTML round-trips through the unscoped rule.

### Image "expands" to a cover instead of deleting — when it has a caption
Clicking the image's `×` (delete) button **sometimes** left the image in place, re-rendered as a full-width cover, instead of deleting it.

**Root cause:** rhino-editor's `removeFigure` does a fixed-size `tr.delete(pos, pos + 1)`. That only removes the figure when its `nodeSize` is 2 (empty caption); once the figure has a **caption** its `nodeSize > 2`, so the size-1 delete leaves the figure in the document (image persists as a cover, caption text orphaned). That's why it was intermittent — it only happened when the image had a caption. (The latest rhino-editor has the same code, with a comment that it *"doesnt always delete the attachment"*.)

**Fix:** override `removeFigure` (by wrapping the figure node view) to delete the whole node by its real `node.nodeSize`.

### Media library pagination redirected out of the modal (item #4)
The attach-media link passed no `turbo_frame`, so the media library's pagination links defaulted to `data-turbo-frame="_top"` and reloaded the **whole page** instead of staying in the modal. Now we pass `turbo_frame: Avo::MODAL_FRAME_ID`; pagy preserves the param across pages, so pagination stays inside the modal.

## Verification (in `main.avodemo.com`, Post#body rhino field)

| Scenario | Before | After |
|---|---|---|
| Open a saved post with an editor-uploaded image | image shown **twice** (inline + cover) | shown **once** |
| Save → edit again | duplicates | single image, stable across save/edit cycles |
| Delete an image (no caption) | inline removed, **cover copy remains** | image fully removed |
| Delete an image **with a caption** | image **stays as a full-width cover** | image + caption fully removed |
| Media library → click a different page | full-page redirect out of the modal | stays in the modal, loads the next page |

## Notes
- Item #1 (CORS) is an S3 bucket-config concern, not gem code; item #2 (caption position) could not be reproduced (caption stays under the image); item #3 (loading bar) and item #5 (docs) are not included here.
- The built JS bundle (`app/assets/builds/…`) is gitignored and produced at publish time (`yarn prod:build`), so only source changes are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)